### PR TITLE
Conditionally import FoundationNetworking

### DIFF
--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -1,5 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
 import FoundationNetworking
+#endif
 
 func download(from urlString: String, to destination: URL) throws {
     guard let url = URL(string: urlString) else {


### PR DESCRIPTION
## Summary
- use `canImport` to conditionally import FoundationNetworking so the code works on macOS and Linux

## Testing
- `swift build`

------
https://chatgpt.com/codex/tasks/task_e_6844ac00daa08320a65b8afd4b364304